### PR TITLE
force for factory to use same standard as yast-core. Remove workaround f...

### DIFF
--- a/package/yast2-gtk.changes
+++ b/package/yast2-gtk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 21 16:35:10 UTC 2012 - jreidinger@suse.com
+
+- fix bnc#767666 segfault of gtk sw_single during search 
+- remove workaround for forcing old gcc
+
+-------------------------------------------------------------------
 Mon Apr 30 10:25:22 CEST 2012 - tgoettlicher@suse.de
 
 - Fix for bnc #722053 by Michael Meeks

--- a/yast2-gtk.spec.in
+++ b/yast2-gtk.spec.in
@@ -16,12 +16,7 @@ BuildRequires:  libzypp-devel >= 6.3.0
 %if 0%{?suse_version} < 1220
 BuildRequires:  libxcrypt-devel
 %endif
-%if 0%{?force_gcc_46}
-BuildRequires:  gcc46
-BuildRequires:  gcc46-c++
-%else
 BuildRequires:  gcc-c++ >= 4.6
-%endif
 
 Requires:       gtk3
 Requires:       yast2-libyui >= 2.18.8
@@ -43,7 +38,8 @@ the X Window System.
 mkdir build
 cd build
 export CFLAGS="$RPM_OPT_FLAGS"
-export CXXFLAGS="$CFLAGS"
+#force to use same c++ standard as yast-core bnc#767666
+export CXXFLAGS="$CFLAGS --std=c++1x"
 cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} \
       -DLIB=%{_lib} \
       -DCMAKE_BUILD_TYPE=Release \
@@ -53,10 +49,6 @@ make %{?_smp_mflags} VERBOSE=1
 
 %install
 cd build
-%if 0%{?force_gcc_46}
-export CC=gcc-4.6
-export CXX=g++-4.6
-%endif
 make install DESTDIR=$RPM_BUILD_ROOT
 cd ..
 


### PR DESCRIPTION
...or lower gcc as it is not needed anymore.

Note: It is already applied to factory as this bug is ship stopper. For details see bug mentioned in comment
