### PR TITLE
Added title and icon management to YGAplication

### DIFF
--- a/src/YGDialog.cc
+++ b/src/YGDialog.cc
@@ -91,12 +91,22 @@ public:
 					atk_object_set_role (peer, ATK_ROLE_DIALOG);
 		    }
 		    else {
+#ifdef LIBYUI_VERSION_NUM
+ #if LIBYUI_VERSION_AT_LEAST(2,42,3)	
 						gtk_window_set_title (window, YUI::app()->applicationTitle().c_str());
 						GdkPixbuf *pixbuf = YGUtils::loadPixbuf (YUI::app()->applicationIcon());
 						if (pixbuf) {  // default window icon
 							gtk_window_set_default_icon (pixbuf);
 							g_object_unref (G_OBJECT (pixbuf));
 						}
+ #else
+						// to be back compatible
+						gtk_window_set_title (window, "YaST");
+ #endif
+#else
+						// to be back compatible
+						gtk_window_set_title (window, "YaST");
+#endif
 		        if (YGUI::ui()->unsetBorder())
 		            gtk_window_set_decorated (window, FALSE);
 		    }

--- a/src/YGUI.cc
+++ b/src/YGUI.cc
@@ -598,12 +598,6 @@ long YGApplication::displayColors()
 int YGApplication::defaultWidth() { return MIN (displayWidth(), 1024); }
 int YGApplication::defaultHeight() { return MIN (displayHeight(), 768); }
 
-void YGApplication::setApplicationTitle(const std::string& title)
-{
-	YApplication::setApplicationTitle ( title );
-	
-}
-
 YWidgetFactory *YGUI::createWidgetFactory()
 { return new YGWidgetFactory; }
 YOptionalWidgetFactory *YGUI::createOptionalWidgetFactory()

--- a/src/YGUI.h
+++ b/src/YGUI.h
@@ -216,14 +216,6 @@ public:
 
 	virtual bool openContextMenu (const YItemCollection &itemCollection);
 	
-	/**
-	 * Set the application title
-	 *
-	 * Reimplemented from YApplication.
-	 **/
-	virtual void setApplicationTitle(const std::string& title);
-
-
 private:
     // for screenshots:
     std::map <std::string, int> screenShotNb;


### PR DESCRIPTION
There is not way at the moment to get rid of window title and icon in yui.
About title gtk always set yast, while qt use argv[0], that for script binding is the name of the language interpret (perl, pyton or ruby), same as in ncurses.

My patch reimplements new libyui api (so it requires new libyui)
