### PR TITLE
Replace deprecated functions

### DIFF
--- a/src/ygtksteps.c
+++ b/src/ygtksteps.c
@@ -137,8 +137,8 @@ GtkWidget* ygtk_steps_new (void)
 gint ygtk_steps_append (YGtkSteps *steps, const gchar *text)
 {
 	GtkWidget *label = gtk_label_new (text);
-	GdkColor black = { 0, 0, 0, 0 };
-	gtk_widget_modify_fg (label, GTK_STATE_NORMAL, &black);
+	GdkRGBA black = { 0.0, 0.0, 0.0, 1.0 };
+	gtk_widget_override_color (label, GTK_STATE_NORMAL, &black);
 	gtk_misc_set_alignment (GTK_MISC (label), 0, 0);
 	int mark_width = 10;
 	pango_layout_get_pixel_size (steps->check_mark_layout, &mark_width, NULL);
@@ -151,8 +151,8 @@ gint ygtk_steps_append (YGtkSteps *steps, const gchar *text)
 void ygtk_steps_append_heading (YGtkSteps *steps, const gchar *heading)
 {
 	GtkWidget *label = gtk_label_new (heading);
-	GdkColor black = { 0, 0, 0, 0 };
-	gtk_widget_modify_fg (label, GTK_STATE_NORMAL, &black);
+	GdkRGBA black = { 0.0, 0.0, 0.0, 1.0 };
+	gtk_widget_override_color (label, GTK_STATE_NORMAL, &black);
 	g_object_set_data (G_OBJECT (label), "is-header", GINT_TO_POINTER (1));
 	gtk_misc_set_alignment (GTK_MISC (label), 0, 0);
 

--- a/src/ygtkwizard.c
+++ b/src/ygtkwizard.c
@@ -46,10 +46,10 @@ static void ygtk_help_dialog_find_next (YGtkHelpDialog *dialog)
 
 static void search_entry_changed_cb (GtkEditable *editable, YGtkHelpDialog *dialog)
 {
-	static GdkColor red = { 0, 255 << 8, 102 << 8, 102 << 8 };
-	static GdkColor white = { 0, 0xffff, 0xffff, 0xffff };
-	static GdkColor yellow = { 0, 0xf7f7, 0xf7f7, 0xbdbd };
-	static GdkColor black = { 0, 0, 0, 0 };
+	static GdkRGBA red = { 1.0, 0.4, 0.4, 1.0 };
+	static GdkRGBA white = { 1.0, 1.0, 1.0, 1.0 };
+	static GdkRGBA yellow = { 0.9686, 0.9686, 0.7411 };
+	static GdkRGBA black = { 0.0, 0.0, 0.0, 1.0 };
 
 	GtkWidget *widget = GTK_WIDGET (editable);
 	GtkEntry *entry = GTK_ENTRY (editable);
@@ -57,16 +57,16 @@ static void search_entry_changed_cb (GtkEditable *editable, YGtkHelpDialog *dial
 	gboolean found = ygtk_html_wrap_search (dialog->help_text, text);
 
 	if (found && *text) {
-		gtk_widget_modify_base (widget, GTK_STATE_NORMAL, &yellow);
-		gtk_widget_modify_text (widget, GTK_STATE_NORMAL, &black);
+		gtk_widget_override_background_color (widget, GTK_STATE_NORMAL, &yellow);
+		gtk_widget_override_color (widget, GTK_STATE_NORMAL, &black);
 	}
 	else if (found) {  // revert
-		gtk_widget_modify_base (widget, GTK_STATE_NORMAL, NULL);
-		gtk_widget_modify_text (widget, GTK_STATE_NORMAL, NULL);
+		gtk_widget_override_background_color (widget, GTK_STATE_NORMAL, NULL);
+		gtk_widget_override_color (widget, GTK_STATE_NORMAL, NULL);
 	}
 	else {
-		gtk_widget_modify_base (widget, GTK_STATE_NORMAL, &red);
-		gtk_widget_modify_text (widget, GTK_STATE_NORMAL, &white);
+		gtk_widget_override_background_color (widget, GTK_STATE_NORMAL, &red);
+		gtk_widget_override_color (widget, GTK_STATE_NORMAL, &white);
 		gtk_widget_error_bell (widget);
 	}
 
@@ -103,8 +103,8 @@ static void ygtk_help_dialog_init (YGtkHelpDialog *dialog)
 	gtk_container_set_border_width (GTK_CONTAINER (dialog), 6);
 	gtk_window_set_type_hint (GTK_WINDOW (dialog), GDK_WINDOW_TYPE_HINT_DIALOG);
 	gtk_window_set_title (GTK_WINDOW (dialog), _("Help"));
-	GdkPixbuf *icon = gtk_widget_render_icon (
-		GTK_WIDGET (dialog), GTK_STOCK_HELP, GTK_ICON_SIZE_MENU, NULL);
+	GdkPixbuf *icon = gtk_widget_render_icon_pixbuf (
+		GTK_WIDGET (dialog), GTK_STOCK_HELP, GTK_ICON_SIZE_MENU);
 	gtk_window_set_icon (GTK_WINDOW (dialog), icon);
 	g_object_unref (G_OBJECT (icon));
 	gtk_window_set_default_size (GTK_WINDOW (dialog), 500, 450);
@@ -430,21 +430,21 @@ static void description_link_clicked_cb (YGtkLinkLabel *label, YGtkWizardHeader 
 
 static void ygtk_wizard_header_init (YGtkWizardHeader *header)
 {
-	GdkColor white = { 0, 0xffff, 0xffff, 0xffff };
-	gtk_widget_modify_bg (GTK_WIDGET (header), GTK_STATE_NORMAL, &white);
+	GdkRGBA white = { 1.0, 1.0, 1.0, 1.0 };
+	gtk_widget_override_background_color (GTK_WIDGET (header), GTK_STATE_NORMAL, &white);
 
 	header->title = gtk_label_new ("");
 	gtk_label_set_ellipsize (GTK_LABEL (header->title), PANGO_ELLIPSIZE_END);
 	gtk_misc_set_alignment (GTK_MISC (header->title), 0, 0.5);
 	ygutils_setWidgetFont (header->title, PANGO_STYLE_NORMAL, PANGO_WEIGHT_BOLD,
 	                       PANGO_SCALE_X_LARGE);
-	GdkColor black = { 0, 0, 0, 0 };  // set text to black cause of some style colors
-	gtk_widget_modify_fg (header->title, GTK_STATE_NORMAL, &black);
+	GdkRGBA black = { 0.0, 0.0, 0.0, 1.0 };
+	gtk_widget_override_color (header->title, GTK_STATE_NORMAL, &black);
 
 	header->description = ygtk_link_label_new ("", _("more"));
 	g_signal_connect (G_OBJECT (header->description), "link-clicked",
 	                  G_CALLBACK (description_link_clicked_cb), header);
-	gtk_widget_modify_fg (header->description, GTK_STATE_NORMAL, &black);
+	gtk_widget_override_color (header->description, GTK_STATE_NORMAL, &black);
 
 	header->icon = gtk_image_new();
 


### PR DESCRIPTION
Following functions are deprecated in new GTK, replacing them with still
working counterparts:
- gtk_widget_modify_bg
- gtk_widget_modify_fg
- gtk_widget_modify_base
- gtk_widget_modify_text
- gtk_widget_render_icon

Counterparts are:
- gtk_widget_override_background_color
- gtk_widget_override_color
- gtk_widget_render_icon_pixbuf
