### PR TITLE
Add a Rakefile to include libyui-rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# make continuous integration using rubygem-packaging_rake_tasks and
+# rubygem-libyui-rake.
+# Copyright © 2014 SUSE LLC
+# MIT license
+
+require "libyui/rake"
+
+Libyui::Tasks.configuration do |conf|
+  #lets ignore license check for now
+  conf.skip_license_check << /.*/
+  conf.obs_sr_project = nil
+end


### PR DESCRIPTION
Add a Rakefile to include libyui-rake tasks. This project is not submitted to `openSUSE:Factory`, so I've set `obs_sr_project` to `nil` to avoid problems with the IDS check.