### PR TITLE
Bump the so version to 8 to be compatible with the base libyui

### DIFF
--- a/package/libyui-gtk-doc.spec
+++ b/package/libyui-gtk-doc.spec
@@ -17,7 +17,7 @@
 
 
 %define parent libyui-gtk
-%define so_version 7
+%define so_version 8
 
 Name:           %{parent}-doc
 Version:        2.44.9

--- a/package/libyui-gtk.changes
+++ b/package/libyui-gtk.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Nov 20 15:09:20 UTC 2017 - lslezak@suse.cz
+
+- Bump the so version to 8 to be compatible with the base libyui
+
+-------------------------------------------------------------------
 Fri Apr 14 22:41:23 CEST 2017 - besser82@fedoraproject.org
 
 - Add milestone-greeter when creating UI

--- a/package/libyui-gtk.spec
+++ b/package/libyui-gtk.spec
@@ -21,7 +21,7 @@ Version:        2.44.9
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 7
+%define so_version 8
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel


### PR DESCRIPTION
The Gtk UI is not included in Factory so just bumping the so_version should be enough (keeping the package version as there is no other change).