### PR TITLE
Bump the .so version to 10, implement the new methods (bsc#1132247)

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET( VERSION_MAJOR "2" )
-SET( VERSION_MINOR "44" )
-SET( VERSION_PATCH "10" )
+SET( VERSION_MINOR "45" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_SHA1}" )
 
 ##### This is need for the libyui core, ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "5" )
+SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-gtk-doc.spec
+++ b/package/libyui-gtk-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui-gtk
-%define so_version 9
+%define so_version 10
 
 Name:           %{parent}-doc
-Version:        2.44.10
+Version:        2.45.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 
@@ -31,7 +31,7 @@ BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  graphviz-gnome
-BuildRequires:  libyui-devel >= 3.0.4
+BuildRequires:  libyui-devel >= 3.5.0
 BuildRequires:  texlive-latex
 
 Url:            http://github.com/libyui/

--- a/package/libyui-gtk.changes
+++ b/package/libyui-gtk.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 12 06:59:41 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump the .so version to 10 to be compatible with the other
+  libyui packages (bsc#1132247)
+- 2.45.0
+
+-------------------------------------------------------------------
 Tue Aug 21 09:02:47 CEST 2018 - schubi@suse.de
 
 - Changed dir of COPYING file.

--- a/package/libyui-gtk.spec
+++ b/package/libyui-gtk.spec
@@ -17,18 +17,18 @@
 
 
 Name:           libyui-gtk
-Version:        2.44.10
+Version:        2.45.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 9
+%define so_version 10
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel
 BuildRequires:  cmake >= 2.8
 BuildRequires:  gcc-c++
 BuildRequires:  gtk3-devel
-BuildRequires:  libyui-devel >= 3.0.4
+BuildRequires:  libyui-devel >= 3.5.0
 BuildRequires:  pkg-config
 Provides:       yui_backend = %{so_version}
 

--- a/src/YGPushButton.cc
+++ b/src/YGPushButton.cc
@@ -156,6 +156,11 @@ public:
 		}
 	}
 
+        virtual void activate()
+        {
+                gtk_button_clicked(GTK_BUTTON (getWidget()));
+        }
+
 	static bool hasIcon (YWidget *ywidget)
 	{
 		if (dynamic_cast <YPushButton *> (ywidget)) {

--- a/src/YGWizard.cc
+++ b/src/YGWizard.cc
@@ -69,6 +69,11 @@ class YGWizard : public YWizard, public YGWidget
 		inline GtkWidget *getWidget() { return m_widget; }
 		inline YGtkWizard *getWizard() { return YGTK_WIZARD (m_wizard->getWidget()); }
 
+                virtual void activate()
+                {
+                        gtk_button_clicked(GTK_BUTTON (getWidget()));
+                }
+
 		private:
 			GtkWidget *m_widget;
 			YGWizard *m_wizard;
@@ -170,10 +175,24 @@ public:
 		YGDialog::currentDialog()->setTitle (heading, false);
 	}
 
+        virtual std::string getDialogHeading()
+        {
+                #warning YGWizard::getDialogHeading() not implemented yet
+                yuiWarning() << "YGWizard::getDialogHeading() not implemented yet" << std::endl;
+                return std::string();
+        }
+
 	virtual void setDialogTitle (const std::string &title)
 	{
 		YGDialog::currentDialog()->setTitle (title, true);
 	}
+
+        virtual std::string getDialogTitle()
+        {
+                #warning YGWizard::getDialogTitle() not implemented yet
+                yuiWarning() << "YGWizard::getDialogTitle() not implemented yet" << std::endl;
+                return std::string();
+        }
 
 	virtual void addStepHeading (const std::string &text)
 	{


### PR DESCRIPTION
- Bump the .so version to 10 (bsc#1132247)
- I'm not an Gtk expert, I do not know how to implement the `getDialogHeading()`/`getDialogTitle()` methods, I left them empty (with a compile time / run time warning).
- As these are so far only needed for the REST API, which is not supported here and the Gtk UI has been dropped in openSUSE/SLE, I left that for the community if anybody is interested in that.
- Travis fails as it depends on the new libyui base, it builds fine in https://build.opensuse.org/project/monitor/home:lslezak:libyui-rest-api