### PR TITLE
Fixed warning Source ID xxxx was not found when attempting to remove it

### DIFF
--- a/package/libyui-gtk-doc.spec
+++ b/package/libyui-gtk-doc.spec
@@ -17,7 +17,7 @@
 
 
 %define parent libyui-gtk
-%define so_version 11
+%define so_version 12
 
 Name:           %{parent}-doc
 Version:        2.48.0

--- a/package/libyui-gtk.spec
+++ b/package/libyui-gtk.spec
@@ -21,7 +21,7 @@ Version:        2.48.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel

--- a/src/YGUI.cc
+++ b/src/YGUI.cc
@@ -245,6 +245,7 @@ YEvent *YGUI::waitInput (unsigned long timeout_ms, bool block)
 	guint timeout = 0;
 
 	if (timeout_ms > 0)
+		// timeout is automatically removed if callback returns FALSE
 		timeout = g_timeout_add (timeout_ms,
 			(GSourceFunc) user_input_timeout_cb, this);
 
@@ -258,9 +259,6 @@ YEvent *YGUI::waitInput (unsigned long timeout_ms, bool block)
 	YEvent *event = NULL;
 	if (pendingEvent())
 		event = m_event_handler.consumePendingEvent();
-
-	if (timeout)
-		g_source_remove (timeout);
 
 	if (block) {  // if YCP keeps working for more than X time, set busy cursor
 		if (busy_timeout)


### PR DESCRIPTION
This warning is got when using YDialog waitForEvent with timeout.
According to [g_timeout_add](https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-timeout-add) manual the callback is called repeatedly until it returns FALSE, at which point the timeout is automatically destroyed and the function will not be called again.

This is the case [here](https://github.com/libyui/libyui-gtk/blob/master/src/YGUI.cc#L228-L233).

This patch fixes the problem.